### PR TITLE
allow strict parsing (to disallow key duplicates in mapping)

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -15,6 +15,7 @@ import (
 var (
 	datafileFlag = flag.String("data", "", "Datafile")
 	tmplFlag     = flag.String("tmpl", "", "Template")
+	strictFlag   = flag.Bool("strict", false, "Strict YAML unmarshalling (fail if mapping keys contain duplicates)")
 
 	tmpl []byte
 	data map[string]interface{}
@@ -92,7 +93,11 @@ func parse(filepath string) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	err = yaml.Unmarshal(dataBytes, &d)
+	if *strictFlag {
+		err = yaml.UnmarshalStrict(dataBytes, &d)
+	} else {
+		err = yaml.Unmarshal(dataBytes, &d)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +168,6 @@ func recursivelyStringifyMapKey(v interface{}) (interface{}, error) {
 	}
 	return casted_v, nil
 }
-
 
 // merge takes two maps and merges them. on collision b overwrites a
 func merge(a, b map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
By default YAML parser ignores dupes, but it may be interesting to catch them and fail.

Example of failure for sample config
```diff
diff --git a/test/my-data.yaml b/test/my-data.yaml
index aa0f52f..2dcf546 100644
--- a/test/my-data.yaml
+++ b/test/my-data.yaml
@@ -1,4 +1,5 @@
 root:
   key1: value1
   key2: 1
+  key2: 1
 root2: test
```

Output:
```
panic: yaml: unmarshal errors:
  line 4: key "key2" already set in map
```